### PR TITLE
System level docker function refactor

### DIFF
--- a/src/rockstor/storageadmin/views/__init__.py
+++ b/src/rockstor/storageadmin/views/__init__.py
@@ -27,9 +27,10 @@ from appliances import (ApplianceListView, ApplianceDetailView)  # noqa F401
 from login import LoginView  # noqa F401
 from user import (UserListView, UserDetailView)  # noqa F401
 from dashboardconfig import DashboardConfigView  # noqa F401
-from network import (NetworkDeviceListView,  # noqa F401
-                     NetworkConnectionListView, NetworkStateView,
-                     NetworkConnectionDetailView)
+from storageadmin.views.network import (NetworkDeviceListView,
+                                        NetworkConnectionListView,
+                                        NetworkStateView,
+                                        NetworkConnectionDetailView)
 from pool_scrub import PoolScrubView  # noqa F401
 from setup_user import SetupUserView  # noqa F401
 from share_acl import ShareACLView  # noqa F401

--- a/src/rockstor/storageadmin/views/network.py
+++ b/src/rockstor/storageadmin/views/network.py
@@ -30,9 +30,9 @@ from storageadmin.serializers import (NetworkDeviceSerializer,
                                       NetworkConnectionSerializer)
 from storageadmin.views.rockon_helpers import (dnet_create, dnet_remove,
                                                probe_running_containers,
-                                               dnet_connect, dnet_disconnect,
-                                               docker_status)
-from system import network
+                                               dnet_connect, dnet_disconnect)
+from system.docker import docker_status
+import system.network as sysnet
 import rest_framework_custom as rfc
 
 import logging
@@ -128,7 +128,7 @@ class NetworkMixin(object):
     @transaction.atomic
     def _refresh_connections(cls):
         logger.debug('The function _refresh_connections has been called')
-        cmap = network.get_con_config(network.get_con_list())
+        cmap = sysnet.get_con_config(sysnet.get_con_list())
         defer_master_updates = []
         for nco in NetworkConnection.objects.all():
             if (nco.uuid not in cmap):
@@ -172,7 +172,7 @@ class NetworkMixin(object):
     @staticmethod
     @transaction.atomic
     def _refresh_devices():
-        dmap = network.get_dev_config(network.get_dev_list())
+        dmap = sysnet.get_dev_config(sysnet.get_dev_list())
 
         def update_connection(dconfig):
             if ('connection' in dconfig):
@@ -294,14 +294,14 @@ class NetworkConnectionListView(rfc.GenericView, NetworkMixin):
                                                       self.team_profiles)
                     handle_exception(Exception(e_msg), request)
                 self._validate_devices(devices, request)
-                network.new_team_connection(name, self.runners[team_profile],
+                sysnet.new_team_connection(name, self.runners[team_profile],
                                             devices, ipaddr, gateway,
                                             dns_servers, search_domains)
 
             elif (ctype == 'ethernet'):
                 device = request.data.get('device')
                 self._validate_devices([device], request, size=1)
-                network.new_ethernet_connection(name, device, ipaddr, gateway,
+                sysnet.new_ethernet_connection(name, device, ipaddr, gateway,
                                                 dns_servers, search_domains)
 
             elif (ctype == 'bond'):
@@ -312,7 +312,7 @@ class NetworkConnectionListView(rfc.GenericView, NetworkMixin):
                                                       self.bond_profiles)
                     handle_exception(Exception(e_msg), request)
                 self._validate_devices(devices, request)
-                network.new_bond_connection(name, bond_profile, devices,
+                sysnet.new_bond_connection(name, bond_profile, devices,
                                             ipaddr, gateway, dns_servers,
                                             search_domains)
 
@@ -380,7 +380,7 @@ class NetworkConnectionDetailView(rfc.GenericView, NetworkMixin):
             if (nco.ctype == 'ethernet'):
                 device = nco.networkdevice_set.first().name
                 self._delete_connection(nco)
-                network.new_ethernet_connection(nco.name, device, ipaddr,
+                sysnet.new_ethernet_connection(nco.name, device, ipaddr,
                                                 gateway, dns_servers,
                                                 search_domains, mtu)
             elif (nco.ctype == 'team'):
@@ -390,7 +390,7 @@ class NetworkConnectionDetailView(rfc.GenericView, NetworkMixin):
                     devices.append(child_nco.networkdevice_set.first().name)
 
                 self._delete_connection(nco)
-                network.new_team_connection(
+                sysnet.new_team_connection(
                     nco.name, self.runners[team_profile], devices, ipaddr,
                     gateway, dns_servers, search_domains, mtu)
             elif (ctype == 'docker'):
@@ -499,8 +499,8 @@ class NetworkConnectionDetailView(rfc.GenericView, NetworkMixin):
     def _delete_connection(nco):
         logger.debug('the _delete method was called')
         for mnco in nco.networkconnection_set.all():
-            network.delete_connection(mnco.uuid)
-        network.delete_connection(nco.uuid)
+            sysnet.delete_connection(mnco.uuid)
+        sysnet.delete_connection(nco.uuid)
         nco.delete()
 
     @transaction.atomic
@@ -549,9 +549,9 @@ class NetworkConnectionDetailView(rfc.GenericView, NetworkMixin):
                 # be brought up in order. eg: active-backup.
                 for mnco in nco.networkconnection_set.all().order_by('name'):
                     logger.debug('upping {} {}'.format(mnco.name, mnco.uuid))
-                    network.toggle_connection(mnco.uuid, switch)
+                    sysnet.toggle_connection(mnco.uuid, switch)
             else:
-                network.toggle_connection(nco.uuid, switch)
+                sysnet.toggle_connection(nco.uuid, switch)
             return Response(NetworkConnectionSerializer(nco).data)
 
 

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -28,7 +28,8 @@ from storageadmin.models import (RockOn, DImage, DContainer, DPort, DVolume,
 from storageadmin.serializers import RockOnSerializer
 from storageadmin.util import handle_exception
 import rest_framework_custom as rfc
-from rockon_helpers import (docker_status, rockon_status)
+from rockon_helpers import rockon_status
+from system.docker import docker_status
 from django_ztask.models import Task
 from django.conf import settings
 import pickle

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -385,7 +385,7 @@ def dnet_create(network, aux_address=None, dgateway=None, host_binding=None,
         # run_command(list(DNET) + ['create', network, ])
         if update:
             logger.debug('A forced update of network connections was requested.')
-            NetworkMixin._refresh_connections()
+            # NetworkMixin._refresh_connections()
     else:
         logger.debug('the network {} was detected, so do NOT create it.'.format(network))
 

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -22,7 +22,6 @@ from system.osi import run_command
 from django.conf import settings
 from django_ztask.decorators import task
 from cli.api_wrapper import APIWrapper
-from system.services import service_status
 from storageadmin.models import (RockOn, DContainer, DVolume, DPort,
                                  DCustomConfig, DContainerLink,
                                  ContainerOption, DContainerEnv,
@@ -31,7 +30,6 @@ from storageadmin.models import (RockOn, DContainer, DVolume, DPort,
 from fs.btrfs import mount_share
 from rockon_utils import container_status
 import logging
-import json
 
 DOCKER = '/usr/bin/docker'
 ROCKON_URL = 'https://localhost/api/rockons'
@@ -41,13 +39,6 @@ DNET = [DOCKER, 'network', ]
 
 logger = logging.getLogger(__name__)
 aw = APIWrapper()
-
-
-def docker_status():
-    o, e, rc = service_status('docker')
-    if (rc != 0):
-        return False
-    return True
 
 
 def rockon_status(name):
@@ -251,49 +242,15 @@ def envars(container):
     return var_list
 
 
-def dnets(id=None, type=None):
-    """
-    List the docker names of all docker networks.
-    :param id: string, used to test for network presence.
-    :param type: string, either 'custom' or 'builtin'
-    :return: list
-    """
-    cmd = list(DNET) + ['ls',
-                        # '--filter', 'type=custom',
-                        '--format', '{{.Name}}']
-    if id:
-        cmd.extend(['--filter', 'id={}'.format(id)])
-    if type is not None:
-        if (type == 'custom'):
-            cmd.extend((['--filter', 'type=custom']))
-        elif (type == 'builtin'):
-            cmd.extend((['--filter', 'type=builtin']))
-        else:
-            raise Exception('type must be custom or builtin')
-    o, e, rc = run_command(cmd)
-    return o[:-1]
-
-
-def dnet_inspect(dname):
-    """
-    This function takes the name of a docker network as argument
-    and returns a dict of its configuration.
-    :param dname: docker network name
-    :return: dict
-    """
-    cmd = list(DNET) + ['inspect', dname, '--format', '{{json .}}', ]
-    o,_,_ = run_command(cmd)
-    return json.loads(o[0])
-
-
 def probe_running_containers(container=None, network=None, all=False):
     """
     List docker containers.
-    :param container:
+    :param container: container name
     :param network:
     :param all:
     :return:
     """
+    # TODO: Consider moving to system.docker
     cmd = [DOCKER, 'ps', '--format', '{{.Names}}', ]
     running_filters = ['--filter', 'status=created',
                        '--filter', 'status=restarting',

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -26,10 +26,10 @@ from storageadmin.models import (RockOn, DContainer, DVolume, DContainerDevice,
 from storageadmin.serializers import RockOnSerializer
 import rest_framework_custom as rfc
 from storageadmin.util import handle_exception
-from rockon_helpers import (docker_status, start, stop, install, uninstall,
+from rockon_helpers import (start, stop, install, uninstall,
                             update, dnet_remove, dnet_create, dnet_disconnect)
 from system.services import superctl
-from network import NetworkMixin
+from system.docker import docker_status
 
 import logging
 logger = logging.getLogger(__name__)

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -288,7 +288,7 @@ class RockOnIdView(rfc.GenericView):
                                     dnet_create(network=net)
                                     # @todo: integrate the forced update of network connections
                                     #   into dnet_create() with an optional flag `update=True`
-                                    NetworkMixin._refresh_connections()
+                                    # NetworkMixin._refresh_connections()
                                 brco = BridgeConnection.objects.get(docker_name=net)
                                 co = DContainer.objects.get(rockon=rockon, name=c)
                                 logger.debug('The container ({}) is {}'.format(co.id, co.name))

--- a/src/rockstor/system/docker.py
+++ b/src/rockstor/system/docker.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2014 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -18,32 +18,98 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from osi import run_command
 import collections
-Image = collections.namedtuple('Image', 'repository tag image_id created '
-                               'virt_size')
-Container = collections.namedtuple('Container', 'container_id image command '
-                                   'created status ports name')
+import json
+from .services import service_status
 
-DOCKER = '/usr/bin/docker'
+Image = collections.namedtuple("Image", "repository tag image_id created " "virt_size")
+Container = collections.namedtuple(
+    "Container", "container_id image command " "created status ports name"
+)
+
+DOCKER = "/usr/bin/docker"
+DNET = [DOCKER, "network"]
 
 
 def image_list():
+    """
+    Appears to be unused currently.
+    :return:
+    """
     images = []
-    o, e, rc = run_command([DOCKER, 'images', ])
+    o, e, rc = run_command([DOCKER, "images"])
     for l in o[1:-1]:
-        cur_image = Image(l[0:20].strip(), l[20:40].strip(),
-                          l[40:60].strip(), l[60:80].strip(),
-                          l[80:].strip())
+        cur_image = Image(
+            l[0:20].strip(),
+            l[20:40].strip(),
+            l[40:60].strip(),
+            l[60:80].strip(),
+            l[80:].strip(),
+        )
         images.append(cur_image)
     return images
 
 
 def container_list():
+    """
+    Appears to be unused currently.
+    :return:
+    """
     containers = []
-    o, e, rc = run_command([DOCKER, 'ps', '-a', ])
+    o, e, rc = run_command([DOCKER, "ps", "-a"])
     for l in o[1:-1]:
-        cur_con = Container(l[0:20].strip(), l[20:40].strip(),
-                            l[40:60].strip(), l[60:80].strip(),
-                            l[80:100].strip(), l[100:120].strip(),
-                            l[120:].strip())
+        cur_con = Container(
+            l[0:20].strip(),
+            l[20:40].strip(),
+            l[40:60].strip(),
+            l[60:80].strip(),
+            l[80:100].strip(),
+            l[100:120].strip(),
+            l[120:].strip(),
+        )
         containers.append(cur_con)
     return containers
+
+
+def dnets(id=None, type=None):
+    """
+    List the docker names of all docker networks.
+    :param id: string, used to test for network presence.
+    :param type: string, either 'custom' or 'builtin'
+    :return: list
+    """
+    cmd = list(DNET) + [
+        "ls",
+        # '--filter', 'type=custom',
+        "--format",
+        "{{.Name}}",
+    ]
+    if id:
+        cmd.extend(["--filter", "id={}".format(id)])
+    if type is not None:
+        if type == "custom":
+            cmd.extend((["--filter", "type=custom"]))
+        elif type == "builtin":
+            cmd.extend((["--filter", "type=builtin"]))
+        else:
+            raise Exception("type must be custom or builtin")
+    o, e, rc = run_command(cmd)
+    return o[:-1]
+
+
+def docker_status():
+    o, e, rc = service_status("docker")
+    if rc != 0:
+        return False
+    return True
+
+
+def dnet_inspect(dname):
+    """
+    This function takes the name of a docker network as argument
+    and returns a dict of its configuration.
+    :param dname: docker network name
+    :return: dict
+    """
+    cmd = list(DNET) + ["inspect", dname, "--format", "{{json .}}"]
+    o, _, _ = run_command(cmd)
+    return json.loads(o[0])

--- a/src/rockstor/system/network.py
+++ b/src/rockstor/system/network.py
@@ -22,8 +22,7 @@ import re
 
 from .exceptions import CommandException
 from .osi import run_command
-from storageadmin.views.rockon_helpers import (dnets, dnet_inspect, docker_status)
-
+from .docker import dnets, docker_status, dnet_inspect
 
 NMCLI = '/usr/bin/nmcli'
 DEFAULT_MTU = 1500


### PR DESCRIPTION
move existing & proposed low level docker functions to system/docker.py

Helps to remove the possibility of circular imports
Move existing docker_status from rockon_helpers to system/docker
Improves separation of concerns between system level docker and Rock-ons
Establish 'sysnet' (system/network) import name space within views
Add TODO for additional system/docker candidate but would cost an import

I'm assuming the NetworkMixin use was a work in progress so remarked out for now.

With this minor re-arrangement we seem to have gained simplicity / stability on the import side.

See what you think. PR to your indicated WIP branch so you can easily see suggestions.

@FroggyFlox Ready for review.

Testing:
Clean build on Tumblweed started and showed network page and your recent system/network unit tests appear to function as expected given included changes:
```
./bin/test --settings=test-settings -v 3 -p test_system_network*
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... FAIL
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
FAIL: test_get_con_config (system.tests.test_system_network.SystemNetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/rockstor-dev/src/rockstor/system/tests/test_system_network.py", line 453, in test_get_con_config
    "expected = ({}).".format(returned, expected),
AssertionError: Un-expected get_con_config() result:
 returned = ({'ecb5c4a6-05ed-4a29-bdd2-2023f691f096': {'bridge': {'aux_address': None, 'subnet': None, 'internal': False, 'host_binding': None, 'docker_name': None, 'icc': False, 'ip_masquerade': False, 'dgateway': None, 'ip_range': None}, 'ctype': 'bridge', 'ipv6_addresses': None, 'ipv4_method': 'manual', 'ipv6_method': None, 'ipv6_dns': None, 'name': 'docker0', 'ipv4_addresses': '172.17.0.1/16', 'ipv6_gw': None, 'ipv4_dns': None, 'state': 'activated', 'ipv6_dns_search': None, 'ipv4_gw': None, 'ipv4_dns_search': None}}).
 expected = ({'ecb5c4a6-05ed-4a29-bdd2-2023f691f096': {'bridge': {}, 'ctype': 'bridge', 'ipv6_addresses': None, 'ipv4_method': 'manual', 'ipv6_method': None, 'ipv6_dns': None, 'name': 'docker0', 'ipv4_addresses': '172.17.0.1/16', 'ipv6_gw': None, 'ipv4_dns': None, 'state': 'activated', 'ipv6_dns_search': None, 'ipv4_gw': None, 'ipv4_dns_search': None}}).

----------------------------------------------------------------------
Ran 6 tests in 0.021s

FAILED (failures=1)
```
No further functional tests as assuming WIP so just build / Web-UI network / Unit test function covered.